### PR TITLE
Add CTFE Factorial Program

### DIFF
--- a/test/programs.d
+++ b/test/programs.d
@@ -59,6 +59,26 @@ const ProgramInfo[] programs = [
 			writeln("Hello, world!");
 		}
 	}),
+	
+	ProgramInfo("ctfe_factorial", "CTFE Factorial", q{
+		import std.stdio;
+
+		uint[] genFactorials(uint n) 
+		{
+		    auto result = new uint[n];
+		    result[0] = 1;
+		    foreach (i; 1 .. n)
+		        result[i] = result[i - 1] * i;
+		    return result;
+		}
+ 
+		enum factorials = genFactorials(30);
+		 
+		void main() 
+		{
+			writeln(factorials);
+		}
+	}),
 ];
 
 struct ExecutionStats


### PR DESCRIPTION
This is a CTFE factorial sample program taken from wikipedia (http://en.wikipedia.org/wiki/Compile_time_function_execution).  I thought it might be useful to see how CTFE performance has changed over time.  It seems too trivial, but it might be interesting to see what the data shows.  Perhaps I'll submit an example with more meat (templates, mixins, etc...) later.

I only tested the program in DPaste.  I didn't test this precise code modification.  I hope I didn't fat-finger something.
